### PR TITLE
Update sampleapp-tvos-swift.xcscheme

### DIFF
--- a/sampleapp-tvos-swift.xcodeproj/xcshareddata/xcschemes/sampleapp-tvos-swift.xcscheme
+++ b/sampleapp-tvos-swift.xcodeproj/xcshareddata/xcschemes/sampleapp-tvos-swift.xcscheme
@@ -1,78 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
-   version = "1.3">
+   LastUpgradeVersion="1250"
+   version="1.4">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables="YES"
+      buildImplicitDependencies="YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForTesting="YES"
+            buildForRunning="YES"
+            buildForProfiling="YES"
+            buildForArchiving="YES"
+            buildForAnalyzing="YES">
             <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D89A2BDE26BD2590009C6942"
-               BuildableName = "sampleapp-tvos-swift.app"
-               BlueprintName = "sampleapp-tvos-swift"
-               ReferencedContainer = "container:sampleapp-tvos-swift.xcodeproj">
+               BuildableIdentifier="primary"
+               BlueprintIdentifier="D89A2BDE26BD2590009C6942"
+               BuildableName="sampleapp-tvos-swift.app"
+               BlueprintName="sampleapp-tvos-swift"
+               ReferencedContainer="container:sampleapp-tvos-swift.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      buildConfiguration="Debug"
+      selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv="YES">
       <Testables>
+         <!-- Add testable targets here -->
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "0"
-      useCustomWorkingDirectory = "NO"
-      ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "YES"
-      debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      buildConfiguration="Debug"
+      selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle="0"
+      useCustomWorkingDirectory="NO"
+      ignoresPersistentStateOnLaunch="NO"
+      debugDocumentVersioning="YES"
+      debugServiceExtension="internal"
+      allowLocationSimulation="YES">
       <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+         runnableDebuggingMode="0">
          <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D89A2BDE26BD2590009C6942"
-            BuildableName = "sampleapp-tvos-swift.app"
-            BlueprintName = "sampleapp-tvos-swift"
-            ReferencedContainer = "container:sampleapp-tvos-swift.xcodeproj">
+            BuildableIdentifier="primary"
+            BlueprintIdentifier="D89A2BDE26BD2590009C6942"
+            BuildableName="sampleapp-tvos-swift.app"
+            BlueprintName="sampleapp-tvos-swift"
+            ReferencedContainer="container:sampleapp-tvos-swift.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      savedToolIdentifier = ""
-      useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
+      buildConfiguration="Release"
+      shouldUseLaunchSchemeArgsEnv="YES"
+      savedToolIdentifier=""
+      useCustomWorkingDirectory="NO"
+      debugDocumentVersioning="YES">
       <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+         runnableDebuggingMode="0">
          <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D89A2BDE26BD2590009C6942"
-            BuildableName = "sampleapp-tvos-swift.app"
-            BlueprintName = "sampleapp-tvos-swift"
-            ReferencedContainer = "container:sampleapp-tvos-swift.xcodeproj">
+            BuildableIdentifier="primary"
+            BlueprintIdentifier="D89A2BDE26BD2590009C6942"
+            BuildableName="sampleapp-tvos-swift.app"
+            BlueprintName="sampleapp-tvos-swift"
+            ReferencedContainer="container:sampleapp-tvos-swift.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration="Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
-      revealArchiveInOrganizer = "YES">
+      buildConfiguration="Release"
+      revealArchiveInOrganizer="YES">
    </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
pdated the version attribute of the <Scheme> element to "1.4" to reflect the latest Xcode version.

Added a placeholder comment inside the <Testables> section to indicate where you can add testable targets from your Xcode project.